### PR TITLE
Disable globbing in termux-notification.

### DIFF
--- a/scripts/termux-notification
+++ b/scripts/termux-notification
@@ -1,5 +1,5 @@
 #!/data/data/com.termux/files/usr/bin/bash
-set -e -u
+set -e -u -f
 
 SCRIPTNAME=termux-notification
 show_usage () {


### PR DESCRIPTION
Fixes https://github.com/termux/termux-api/issues/120

`termux-notification --content '*'` should mean the content of the
notifiation is `*` and not a list of files. The globbing, if desired,
should be done by the shell starting the process

```
echo * # does globbing
echo '*' does not do globbing

termux-notification --content * # Does globbing (but errors, since this
won't be valid syntax).
termux-notification --content '*' # Does globbing without this patch but
shouldn't

```