### PR TITLE
Add termux-microphone-record

### DIFF
--- a/scripts/termux-microphone-record
+++ b/scripts/termux-microphone-record
@@ -1,0 +1,77 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -e
+
+SCRIPTNAME=termux-microphone-record
+
+show_usage () {
+    echo "Usage: $SCRIPTNAME [args]"
+    echo "Record using microphone on your device"
+    echo
+    echo "-h           Shows this help"
+    echo "-d           Start recording w/ defaults"
+    echo "-f <file>    Start recording to specific file"
+    echo "-l <limit>   Start recording w/ specified limit (in seconds)"
+    echo "-i           Get info about current recording"
+    echo "-q           Quits recording"
+}
+
+usage_error () {
+    echo
+    show_usage
+    exit 1
+}
+
+sole() {
+    if [ $# -gt 1 ]; then
+        echo "ERROR: No other options should be specified with -$option!"
+        usage_error
+    fi
+}
+
+add_params() {
+    for i in "$@"; do
+        params[index++]="$i"
+    done
+}
+
+call_api () {
+    /data/data/com.termux/files/usr/libexec/termux-api MicRecorder "$@"
+}
+
+while getopts h,f:,l:,d,i,q option
+do
+    case "$option" in
+        h) sole "$@"
+           ;;
+        f) record=yes
+           dir="$(dirname "$OPTARG")"
+           file="$(basename "$OPTARG")"
+           dir="$(realpath "$dir")"
+           add_params --es file "$dir/$file"
+           ;;
+        # API takes limit in  milliseconds
+        l) record=yes
+           add_params --ei limit $((OPTARG * 1000))
+           ;;
+        d) record=yes
+           ;;
+        i) sole "$@"
+           add_params -a info
+           ;;
+        q) sole "$@"
+           add_params -a quit
+           ;;
+        *) usage_error
+           ;;
+    esac
+done
+
+if [ -v record ]; then
+    add_params -a record
+fi
+
+if [ -v params ]; then
+    call_api "${params[@]}"
+else
+    show_usage
+fi

--- a/scripts/termux-microphone-record
+++ b/scripts/termux-microphone-record
@@ -22,7 +22,7 @@ usage_error () {
 }
 
 sole() {
-    if [ $# -gt 1 ]; then
+    if [ "$1 $2" != "-$option $OPTARG" ] || [ $# -gt 2 ]; then
         echo "ERROR: No other options should be specified with -$option!"
         usage_error
     fi
@@ -49,7 +49,7 @@ do
            dir="$(realpath "$dir")"
            add_params --es file "$dir/$file"
            ;;
-        # API takes limit in  milliseconds
+        # API takes limit in milliseconds
         l) record=yes
            add_params --ei limit $((OPTARG * 1000))
            ;;


### PR DESCRIPTION
For https://github.com/termux/termux-api/pull/158, replacing https://github.com/termux/termux-api-package/pull/12

Significant changes:
1. Avoid all the unnecessary "flags" with a single `record` variable.
2. Use an array for params so that proper quoting can be done
3. Use getopts builtin error reporting (for both illegal option and missing required argument) but show usage additionally
4. Avoid redundant code by using a function `sole()` for options that should be solely used; tolerate `-d` to be used with `-f` or `-l` as in the original script
5. use `dirname` + `realpath` instead of `pwd` for possible absolute path (e.g. `/sdcard/somedir/somefile`)