### PR TITLE
Prevent sensor names from being splitted when they contain spaces

### DIFF
--- a/scripts/termux-sensor
+++ b/scripts/termux-sensor
@@ -81,7 +81,7 @@ do
 		a) set_flag $ALL_SENSORS_FLAG; PARAMS="-a sensors $PARAMS --ez all true" ;;
 		c) set_flag $CLEANUP_FLAG; PARAMS="-a cleanup" ;;
 		l) set_flag $LIST_FLAG; PARAMS="-a list" ;;
-		s) set_flag $SENSOR_FLAG; get_sensors $OPTARG; PARAMS="-a sensors --es sensors $OPTARG" ;;
+		s) set_flag $SENSOR_FLAG; get_sensors "$OPTARG"; PARAMS="-a sensors --es sensors $OPTARG" ;;
 		d) set_flag $DELAY_FLAG; get_delay $OPTARG; PARAMS="$PARAMS --ei delay $OPTARG" ;;
 		?) echo "$SCRIPTNAME: illegal option -$OPTARG"; exit 1;
 	esac


### PR DESCRIPTION
Fixes #15