### PR TITLE
termux-speech-to-text script

### DIFF
--- a/scripts/termux-speech-to-text
+++ b/scripts/termux-speech-to-text
@@ -1,0 +1,22 @@
+#!/data/data/com.termux/files/usr/bin/sh
+set -e -u
+
+SCRIPTNAME=termux-speech-to-text
+show_usage () {
+    echo "Usage: $SCRIPTNAME"
+    echo "Converts speech to text, sending partial matches to stdout."
+    exit 0
+}
+
+while getopts :h option
+do
+    case "$option" in
+        h) show_usage;;
+        ?) echo "$SCRIPTNAME: illegal option -$OPTARG"; exit 1;
+    esac
+done
+shift $(($OPTIND-1))
+
+if [ $# != 0 ]; then echo "$SCRIPTNAME: too many arguments"; exit 1; fi
+
+/data/data/com.termux/files/usr/libexec/termux-api SpeechToText


### PR DESCRIPTION
It seems like nothing currently uses https://github.com/termux/termux-api/blob/master/app/src/main/java/com/termux/api/SpeechToTextAPI.java (see https://github.com/termux/termux-api/issues/100), so I tried making a script for it. 

As it doesn't support any options, I didn't add any flags to the script. I can see where options could go on `SpeechToTextAPI.java` (maybe) but I don't have the right setup to be able to contribute to it, so this is it for now.