### PR TITLE
Fix issue where limit lost its parameter

### DIFF
--- a/scripts/termux-sms-list
+++ b/scripts/termux-sms-list
@@ -21,7 +21,7 @@ show_usage () {
     exit 0
 }
 
-while getopts :hdlt:no: option
+while getopts :hdl:t:no: option
 do
     case "$option" in
         h) show_usage;;


### PR DESCRIPTION
Found an issue with my PR #214 which removed the option arg for limit. This is my fault as I didn't have an understanding of bash arguments. This pull request adds it back.