### PR TITLE
termux-call-log: remove invalid option '-d' from the help info

### DIFF
--- a/scripts/termux-call-log
+++ b/scripts/termux-call-log
@@ -8,7 +8,7 @@ PARAMS=""
 SCRIPTNAME=termux-call-log
 
 show_usage () {
-    echo "Usage: $SCRIPTNAME [-d] [-l limit] [-o offset]"
+    echo "Usage: $SCRIPTNAME [-l limit] [-o offset]"
     echo "List call log history"
     echo "  -l limit   offset in call log list (default: $PARAM_LIMIT)"
     echo "  -o offset  offset in call log list (default: $PARAM_OFFSET)"


### PR DESCRIPTION
It appears that option '-d' is unused and shouldn't be displayed in the help message.