### PR TITLE
Fixed termux-toast to allow -s (short) anywhere

### DIFF
--- a/scripts/termux-toast
+++ b/scripts/termux-toast
@@ -19,7 +19,7 @@ while getopts :hsc:b:g: option
 do
     case "$option" in
         h) show_usage;;
-        s) PARAMS=" --ez short true";;
+        s) PARAMS+=" --ez short true";;
         c) PARAMS+=" --es text_color $OPTARG";;
         b) PARAMS+=" --es background $OPTARG";;
         g) PARAMS+=" --es gravity $OPTARG";;


### PR DESCRIPTION
Before, -s had to be used at the very start, as it would completely overwrite the params string instead of appending. This simple fix just makes it append instead of overwrite. (I'm pretty sure this is fine and works but it might be necessary to change something else or it might have to stay like that.)