### PR TITLE
Fix that notifications that don't have content specified hang

### DIFF
--- a/scripts/termux-notification
+++ b/scripts/termux-notification
@@ -41,6 +41,7 @@ OPT_BUTTON2_TEXT=""
 OPT_BUTTON2_ACTION=""
 OPT_BUTTON3_TEXT=""
 OPT_BUTTON3_ACTION=""
+OPT_CONTENT=""
 
 TEMP=`busybox getopt \
      -n $SCRIPTNAME \
@@ -101,9 +102,5 @@ if [ -n "$OPT_SOUND" ]; then set -- "$@" --ez sound "$OPT_SOUND"; fi
 if [ -n "$OPT_TITLE" ]; then set -- "$@" --es title "$OPT_TITLE"; fi
 if [ -n "$OPT_VIBRATE" ]; then set -- "$@" --ela vibrate "$OPT_VIBRATE"; fi
 
-if [ -v OPT_CONTENT ]; then
-	# Note that we want to accept an empty content (--content "").
-	echo ${OPT_CONTENT:=""} | /data/data/com.termux/files/usr/libexec/termux-api Notification "$@"
-else
-	/data/data/com.termux/files/usr/libexec/termux-api Notification "$@"
-fi
+# Note that we want to accept an empty content (--content "").
+echo ${OPT_CONTENT:=""} | /data/data/com.termux/files/usr/libexec/termux-api Notification "$@"


### PR DESCRIPTION
It just sets the content to empty ("") by default, as if there is no content at all it hangs. Fixes #61.