### PR TITLE
Avoid adding trailing newline to copied text

### DIFF
--- a/scripts/termux-clipboard-set
+++ b/scripts/termux-clipboard-set
@@ -21,6 +21,6 @@ CMD="/data/data/com.termux/files/usr/libexec/termux-api Clipboard -e api_version
 if [ $# = 0 ]; then
 	$CMD
 else
-	echo $@ | $CMD
+	echo -n "$@" | $CMD
 fi
 


### PR DESCRIPTION
Using `echo` without options adds a trailing newline. I'm also in the habit of quoting $@ (which keeps separate tokens separate), though it's probably not significant here.