### PR TITLE
Allow signing raw messages in keystore

### DIFF
--- a/scripts/termux-keystore
+++ b/scripts/termux-keystore
@@ -109,7 +109,7 @@ generate_key () {
 
     # purpose 12 is SIGN+VERIFY
     $CMD_BASE -e command generate -e alias "$ALIAS" -e algorithm "$ALGORITHM" \
-        --ei purposes 12 --esa digests SHA-1,SHA-256,SHA-384,SHA-512 \
+        --ei purposes 12 --esa digests NONE,SHA-1,SHA-256,SHA-384,SHA-512 \
         --ei size "$SIZE" -e curve "$CURVE" --ei validity "$VALIDITY"
 }
 


### PR DESCRIPTION
This change adds support for a new digest, NONE.

This was required as [tergent 1.0](https://github.com/aeolwyr/tergent/releases/tag/1.0.0) is now a cryptoki library. When `ssh` calls a cryptoki library it handles hashing internally, therefore the keys need to support this.

The list of possible values can be found in [android.security.keystore.KeyProperties](https://developer.android.com/reference/android/security/keystore/KeyProperties).

---

An open question here is the future of this flag (and similarly the purposes flag). Ideally, a change in this package should not be needed every time a new digest or purpose is needed. However, even allowing the users to edit these using cli parameters does not solve these issues:
* Users will still need to generate new keys as it is not possible to change these values after key generation.
* Let's say the user sets the [ENCRYPT purpose](https://developer.android.com/reference/android/security/keystore/KeyProperties#PURPOSE_ENCRYPT). It is still not possible to encrypt using these keys as currently [KeystoreAPI](https://github.com/termux/termux-api/blob/master/app/src/main/java/com/termux/api/KeystoreAPI) does not set any encryption padding values.

It can be argued we should default to "allow all" in KeystoreAPI which should make the lifes of the users easier, but I am not sure about the security implications of that. Also that kind of implementation will need reflection as Android does not provide a way to get all possible key properties.

In any case such a change will require updates in the [termux-api](https://github.com/termux/termux-api) package too, and I wanted to keep this change as small as possible for now.
