### PR TITLE
Connect over a unix socket before trying to use am

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ target_link_libraries(termux-api-broadcast termux-api)
 
 # TODO: get list through regex or similar
 set(script_files
+  scripts/termux-api-start
+  scripts/termux-api-stop
   scripts/termux-audio-info
   scripts/termux-battery-status
   scripts/termux-brightness

--- a/scripts/termux-api-start.in
+++ b/scripts/termux-api-start.in
@@ -1,0 +1,2 @@
+#!@TERMUX_PREFIX@/bin/sh
+am startservice -n com.termux.api/.KeepAliveService

--- a/scripts/termux-api-stop.in
+++ b/scripts/termux-api-stop.in
@@ -1,0 +1,2 @@
+#!@TERMUX_PREFIX@/bin/sh
+am stopservice -n com.termux.api/.KeepAliveService

--- a/termux-api.h
+++ b/termux-api.h
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 
 _Noreturn void exec_am_broadcast(int, char**, char*, char*);
+_Noreturn void contact_plugin(int, char**, char*, char*);
 _Noreturn void exec_callback(int);
 void generate_uuid(char*);
 void* transmit_stdin_to_socket(void*);


### PR DESCRIPTION
[This is the corresponding PR for this PR for Termux:API](https://github.com/termux/termux-api/pull/471).  
  
Preparing the arguments for transmission is a bit ugly, because of string handling in C. If the transmission fails for whatever reason, it falls back to calling `am`. That makes it work reliably, even if the Termux:API process gets killed while the transmission is in progress.  
  
Would it be possible to use C++ for this file instead, so you can just concatenate the strings and operate on them?
  
I also added 2 new scripts to start and stop the new service easily.