### PR TITLE
Storage get enhanced

### DIFF
--- a/scripts/termux-storage-get.in
+++ b/scripts/termux-storage-get.in
@@ -3,13 +3,13 @@ set -e -u
 
 SCRIPTNAME=termux-storage-get
 show_usage () {
-    echo "Usage: $SCRIPTNAME [-a] [-m] [-l] [-p] [-t mimeType] [output-file]"
+    echo "Usage: $SCRIPTNAME [-w] [-m] [-l] [-p] [-t mimeType] [output-file]"
     echo "    Request a file from the system (and output it to the specified file)."
     echo ""
-    echo "Usage: $SCRIPTNAME -a -f [-l] [-p]"
+    echo "Usage: $SCRIPTNAME -w -f [-l] [-p]"
     echo "    Request a folder and print URI"
     echo ""
-    echo "  -a            asyncronous call (wait until finish) and print URI result"
+    echo "  -w            wait/block until finish (synchronous call) and print URI result"
     echo "  -m            allow to select multiple files"
     echo "  -l            print line(s) of URI instead of json"
     echo "  -t mimeType   MIME type of file to open"
@@ -19,18 +19,18 @@ show_usage () {
     exit 0
 }
 
-async=false
+wait=false
 multiple=false
 json=true
 mimeType='*/*'
 folder=false
 persist=false
 
-while getopts :hamlt:fp option
+while getopts :hwmlt:fp option
 do
     case "$option" in
         h) show_usage;;
-        a) async=true;;
+        w) wait=true;;
         m) multiple=true;;
         l) json=false;;
         t) mimeType="$OPTARG";;
@@ -46,4 +46,4 @@ if [ $# -gt 1 ]; then echo "$SCRIPTNAME: too many arguments"; exit 1; fi
 if [ "$folder" = "true" ] && [ $# -eq 1 ]; then echo "$SCRIPTNAME: too many arguments"; exit 1; fi
 if [ $# -eq 1 ]; then filename="$(realpath "$1")"; fi
 
-@TERMUX_PREFIX@/libexec/termux-api StorageGet --es file "$filename" --ez async "$async" --ez multiple "$multiple" --ez json "$json" --es type "$mimeType" --ez folder "$folder" --ez persist "$persist"
+@TERMUX_PREFIX@/libexec/termux-api StorageGet --es file "$filename" --ez wait "$wait" --ez multiple "$multiple" --ez json "$json" --es type "$mimeType" --ez folder "$folder" --ez persist "$persist"

--- a/scripts/termux-storage-get.in
+++ b/scripts/termux-storage-get.in
@@ -3,22 +3,47 @@ set -e -u
 
 SCRIPTNAME=termux-storage-get
 show_usage () {
-    echo "Usage: $SCRIPTNAME output-file"
-    echo "Request a file from the system and output it to the specified file."
+    echo "Usage: $SCRIPTNAME [-a] [-m] [-l] [-p] [-t mimeType] [output-file]"
+    echo "    Request a file from the system (and output it to the specified file)."
+    echo ""
+    echo "Usage: $SCRIPTNAME -a -f [-l] [-p]"
+    echo "    Request a folder and print URI"
+    echo ""
+    echo "  -a            asyncronous call (wait until finish) and print URI result"
+    echo "  -m            allow to select multiple files"
+    echo "  -l            print line(s) of URI instead of json"
+    echo "  -t mimeType   MIME type of file to open"
+    echo "  -f            pick a folder instead of file"
+    echo "  -p            persistable (persist after rebbot) permission grant"
+    echo "  output-file   output name, use pattern like %d when -m is present"
     exit 0
 }
 
+async=false
+multiple=false
+json=true
+mimeType='*/*'
+folder=false
+persist=false
 
-while getopts :h option
+while getopts :hamlt:fp option
 do
     case "$option" in
         h) show_usage;;
+        a) async=true;;
+        m) multiple=true;;
+        l) json=false;;
+        t) mimeType="$OPTARG";;
+        f) folder=true;;
+        p) persist=true;;
         ?) echo "$SCRIPTNAME: illegal option -$OPTARG"; exit 1;
     esac
 done
 shift $((OPTIND-1))
 
+filename=""
 if [ $# -gt 1 ]; then echo "$SCRIPTNAME: too many arguments"; exit 1; fi
-if [ $# -lt 1 ]; then echo "$SCRIPTNAME: no output file specified"; exit 1; fi
+if [ "$folder" = "true" ] && [ $# -eq 1 ]; then echo "$SCRIPTNAME: too many arguments"; exit 1; fi
+if [ $# -eq 1 ]; then filename="$(realpath "$1")"; fi
 
-@TERMUX_PREFIX@/libexec/termux-api StorageGet --es file "$(realpath "$1")"
+@TERMUX_PREFIX@/libexec/termux-api StorageGet --es file "$filename" --ez async "$async" --ez multiple "$multiple" --ez json "$json" --es type "$mimeType" --ez folder "$folder" --ez persist "$persist"


### PR DESCRIPTION
This goal of this request is to enrich termux-storage-get to what "Open ..." and "Open Folder ..." usually do in PC, while keeping backward compatibility. 

See the `show_usage()` below for more information. 

* high backward compatibility (`termux-storage-get output-name` works as usual)
* print URIs in JSON array (or line format with -l)
* when output-name is not present, only print out URIs
* synchronous call (wait until finish)
* open folder
* persistable permission grant (persist after reboot)
* supprot to get multiple file (accompany with output-name patterns like %d, %8d, %08d)
* specify MIME type
