### PR TITLE
Adds the script to enable/disable ADB wifi

### DIFF
--- a/scripts/termux-adb-wifi-enable
+++ b/scripts/termux-adb-wifi-enable
@@ -1,0 +1,21 @@
+#!/data/data/com.termux/files/usr/bin/sh
+set -e -u
+
+SCRIPTNAME=termux-adb-wifi-enable
+
+show_usage () {
+        echo "Usage: $SCRIPTNAME [true | false]"
+        echo "Toggles ADB Wi-Fi Enabled/Disabled"
+        exit 1
+}
+
+if [ "$#" -ne 1 ]; then
+        show_usage
+fi
+
+case $1 in
+        true|false);;
+        *) show_usage;;
+esac
+
+/data/data/com.termux/files/usr/libexec/termux-api AdbWifiEnable --ez enabled "$1"


### PR DESCRIPTION
This script together with the corresponding commit  in termux-api adds the ability to manage the adb wifi state.

Requires
https://github.com/termux/termux-api/pull/591