### PR TITLE
fix bashism

### DIFF
--- a/scripts/termux-clipboard-set.in
+++ b/scripts/termux-clipboard-set.in
@@ -21,6 +21,6 @@ CMD="@TERMUX_PREFIX@/libexec/termux-api Clipboard -e api_version 2 --ez set true
 if [ $# = 0 ]; then
 	$CMD
 else
-	echo -n "$@" | $CMD
+	printf "%s" "$@" | $CMD
 fi
 


### PR DESCRIPTION
This is also better when running in bash, since if someone did something like `termux-clipboard-set -e` then it would copy the text "-e" rather then copying nothing since its an echo option.