### PR TITLE
Enhance help and option handling for: `scripts/termux-battery-status`

### DIFF
--- a/scripts/termux-battery-status.in
+++ b/scripts/termux-battery-status.in
@@ -1,4 +1,6 @@
 #!@TERMUX_PREFIX@/bin/sh
+# shellcheck shell=bash
+
 set -e -u
 
 SCRIPTNAME=termux-battery-status

--- a/scripts/termux-battery-status.in
+++ b/scripts/termux-battery-status.in
@@ -3,16 +3,20 @@ set -e -u
 
 SCRIPTNAME=termux-battery-status
 show_usage () {
-    echo "Usage: $SCRIPTNAME"
-    echo "Get the status of the device battery."
+    echo "Usage: $SCRIPTNAME
+Get the status of the device battery."
     exit 0
 }
+
+specification=:h
+option_names_as_string="$(echo "$specification" | sed 's/://g' | sed -r 's/(.)/ -\1/g')"
+read -r -a option_names_as_array <<< "$option_names_as_string"
 
 while getopts :h option
 do
     case "$option" in
         h) show_usage;;
-        ?) echo "$SCRIPTNAME: illegal option -$OPTARG"; exit 1;
+        ?) echo "$SCRIPTNAME: illegal option -$OPTARG, expected one of ${option_names_as_array[*]}"; exit 1;
     esac
 done
 shift $((OPTIND-1))


### PR DESCRIPTION
- Use double quotes for `show_usage` function
- Provide valid options when unknown is passed
- Specify script type for ShellCheck to get rid of its complaints