### PR TITLE
Fix malloc&memcpy issue in exec_am_broadcast

### DIFF
--- a/termux-api.c
+++ b/termux-api.c
@@ -8,7 +8,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/endian.h>
+#include <arpa/inet.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/termux-api.c
+++ b/termux-api.c
@@ -248,6 +248,10 @@ _Noreturn void exec_am_broadcast(int argc, char** argv,
 
     int const extra_args = 15; // Including ending NULL.
     char** child_argv = malloc((sizeof(char*)) * (argc + extra_args));
+    if (child_argv == NULL) {
+        perror("malloc failed for am child args");
+        exit(1);
+    }
 
     child_argv[0] = "am";
     child_argv[1] = "broadcast";

--- a/termux-api.c
+++ b/termux-api.c
@@ -275,6 +275,8 @@ _Noreturn void exec_am_broadcast(int argc, char** argv,
     // Use an a executable taking care of PATH and LD_LIBRARY_PATH:
     execv(PREFIX "/bin/am", child_argv);
 
+    // We should not reach here, if we do, then free memory we malloc'ed
+    free(child_argv);
     perror("execv(\"" PREFIX "/bin/am\")");
     exit(1);
 }


### PR DESCRIPTION
If termux-am-socket is not used, then termux-api falls back to the slower exec_am_broadcast method.

If we strip exec_am_broadcast down to something shorter it essentially runs:

<details>
<summary>minimal example of original code</summary>

```c
#include <stdlib.h>
#include <string.h>
#include <stddef.h>
#include <stdio.h>

void exec_am_broadcast(int argc, char **argv)
{
    int const extra_args = 2; // Including ending NULL.
    char** child_argv = malloc((sizeof(char*)) * (argc + extra_args));

    child_argv[0] = "am";
    child_argv[1] = argv[1];

    // Copy the remaining arguments -2 for first binary and second api name:
    memcpy(child_argv + extra_args, argv + 2, (argc-1) * sizeof(char*));

    // End with NULL:
    child_argv[argc + extra_args - 1] = NULL;

    // free added here, not strictly needed in original since function is _Noreturn, but it is needed to make valgrind happy
    free(child_argv);
}

int main(int argc, char **argv)
{
    exec_am_broadcast(argc, argv);
    return 0;
}
```
</details>

If we compile this and run this with a memory checker like valgrind:

```sh
gcc -o test orig-test.c
valgrind --leak-check=full --show-leak-kinds=all -s --track-origins=yes ./test foo bar baz
```

then there are no issues (a NULL termination issue was fixed earlier in
commit [08bcd7331982 ("exec_am_broadcast: fix NULL assignment of last element of child_argv")](https://github.com/termux/termux-api-package/commit/08bcd73319825ccba1804c3f741764bc7decd551) though).

Now let's modify the example to print all the child_argv to see what we have actually set the array to:

<details>
<summary>minimal example with print based on original code</summary>

```c
#include <stdlib.h>
#include <string.h>
#include <stddef.h>
#include <stdio.h>

void exec_am_broadcast(int argc, char **argv)
{
    int const extra_args = 2; // Including ending NULL.
    char** child_argv = malloc((sizeof(char*)) * (argc + extra_args));

    child_argv[0] = "am";
    child_argv[1] = argv[1];

    // Copy the remaining arguments -2 for first binary and second api name:
    memcpy(child_argv + extra_args, argv + 2, (argc-1) * sizeof(char*));

    // End with NULL:
    child_argv[argc + extra_args - 1] = NULL;

    for (int i=0; i<argc+extra_args; i++) {
	printf("child_argv[%d]: %s\n", i, child_argv[i]);
    }

    // free added here, not strictly needed in original since function is _Noreturn, but it is needed to make valgrind happy
    free(child_argv);
}

int main(int argc, char **argv)
{
    exec_am_broadcast(argc, argv);
    return 0;
}
```
</details>

If we compile and run under valgrind it still works fine, but we can see that it contains two NULLs at the end:

```
child_argv[0]: am
child_argv[1]: foo
child_argv[2]: bar
child_argv[3]: baz
child_argv[4]: (null)
child_argv[5]: (null)
```

which is unnecessary, clearly there is a mistake here, but two NULLs at the end does not really cause any issues at this point.

Now let's add a function that calls exec_am_broadcast with some args "manually" (I am doing this in a termux-usb improvement that I am working on):

<details>
<summary>example with call to exec_am_broadcast from another function</summary>

```c
#include <stdlib.h>
#include <string.h>
#include <stddef.h>
#include <stdio.h>

void exec_am_broadcast(int argc, char **argv)
{
    int const extra_args = 2; // Including ending NULL.
    char** child_argv = malloc((sizeof(char*)) * (argc + extra_args));

    child_argv[0] = "am";
    child_argv[1] = argv[1];

    // Copy the remaining arguments -2 for first binary and second api name:
    memcpy(child_argv + extra_args, argv + 2, (argc-1) * sizeof(char*));

    // End with NULL:
    child_argv[argc + extra_args - 1] = NULL;

    for (int i=0; i<argc+extra_args; i++) {
        printf("child_argv[%d]: %s\n", i, child_argv[i]);
    }

    // free added here, not strictly needed in original since function is _Noreturn, but it is needed to make valgrind happy
    free(child_argv);
}

void custom_exec_am_broadcast()
{
    int argc = 3;
    char *argv[argc];

    argv[0] = "foo";
    argv[1] = "bar";
    argv[2] = "baz";

    exec_am_broadcast(argc, argv);
}

int main(int argc, char **argv)
{
    custom_exec_am_broadcast();
    return 0;
}
```
</details>

If we compile this an run it under valgrind as before we get:

```
$ valgrind --leak-check=full --show-leak-kinds=all -s --track-origins=yes ./test 
==20918== Memcheck, a memory error detector
==20918== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.
==20918== Using Valgrind-3.24.0 and LibVEX; rerun with -h for copyright info
==20918== Command: ./test
==20918== 
child_argv[0]: am
child_argv[1]: bar
child_argv[2]: baz
==20918== Conditional jump or move depends on uninitialised value(s)
==20918==    at 0x48FE8E4: __printf_buffer (vfprintf-process-arg.c:408)
==20918==    by 0x49011E3: __vfprintf_internal (vfprintf-internal.c:1544)
==20918==    by 0x48F4EB2: printf (printf.c:33)
==20918==    by 0x109259: exec_am_broadcast (in /home/grimler/termux-api-package/test)
==20918==    by 0x109326: custom_exec_am_broadcast (in /home/grimler/termux-api-package/test)
==20918==    by 0x10935D: main (in /home/grimler/termux-api-package/test)
==20918==  Uninitialised value was created by a stack allocation
==20918==    at 0x10927A: custom_exec_am_broadcast (in /home/grimler/termux-api-package/test)
==20918== 
child_argv[3]: (null)
child_argv[4]: (null)
==20918== 
==20918== HEAP SUMMARY:
==20918==     in use at exit: 0 bytes in 0 blocks
==20918==   total heap usage: 2 allocs, 2 frees, 1,064 bytes allocated
==20918== 
==20918== All heap blocks were freed -- no leaks are possible
==20918== 
==20918== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
==20918== 
==20918== 1 errors in context 1 of 1:
==20918== Conditional jump or move depends on uninitialised value(s)
==20918==    at 0x48FE8E4: __printf_buffer (vfprintf-process-arg.c:408)
==20918==    by 0x49011E3: __vfprintf_internal (vfprintf-internal.c:1544)
==20918==    by 0x48F4EB2: printf (printf.c:33)
==20918==    by 0x109259: exec_am_broadcast (in /home/grimler/termux-api-package/test)
==20918==    by 0x109326: custom_exec_am_broadcast (in /home/grimler/termux-api-package/test)
==20918==    by 0x10935D: main (in /home/grimler/termux-api-package/test)
==20918==  Uninitialised value was created by a stack allocation
==20918==    at 0x10927A: custom_exec_am_broadcast (in /home/grimler/termux-api-package/test)
==20918== 
==20918== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

Oops, child_argv[3] has uninitialised memory. I have no idea why the previous example (where we ran the same but with argv from command line) did not give the same error, maybe someone smarter can explain this?

We can fix our example by memcpy'ing to the child_argv element AFTER the one we set to argv[1], and only copying argc-2 elements (since we start at argv+2):

<details>
<summary>fixed example</summary>

```c
#include <stdlib.h>
#include <string.h>
#include <stddef.h>
#include <stdio.h>

void exec_am_broadcast(int argc, char **argv)
{
    int const extra_args = 1; // Including ending NULL.
    char** child_argv = malloc((sizeof(char*)) * (argc + extra_args));

    child_argv[0] = "am";
    child_argv[1] = argv[1];

    // Copy the remaining arguments -2 for first binary and second api name:
    memcpy(child_argv + extra_args + 1, argv + 2, (argc-2) * sizeof(char*));

    // End with NULL:
    child_argv[argc + extra_args - 1] = NULL;

    for (int i=0; i<argc+extra_args; i++) {
        printf("child_argv[%d]: %s\n", i, child_argv[i]);
    }

    // free added here, not strictly needed in original since function is _Noreturn, but it is needed to make valgrind happy
    free(child_argv);
}

void custom_exec_am_broadcast()
{
    int argc = 3;
    char *argv[argc];

    argv[0] = "foo";
    argv[1] = "bar";
    argv[2] = "baz";

    exec_am_broadcast(argc, argv);
}

int main(int argc, char **argv)
{
    custom_exec_am_broadcast();
    return 0;
}
```
</details>

We then end up with:

```
child_argv[0]: am
child_argv[1]: bar
child_argv[2]: baz
child_argv[3]: (null)
```

and no issues when running under valgrind. Hooray!

---

In the PR I have done essentially the fix described above, and some extra cleanup. See the individual commit messages for the rationale for each small change.
