### PR TITLE
Changed|Added(scripts/termux-nfc): support all NFC APIs

### DIFF
--- a/scripts/termux-nfc.in
+++ b/scripts/termux-nfc.in
@@ -3,45 +3,130 @@
 set -e -u
 
 show_usage() {
-    echo "Usage: termux-nfc [-r [short|full]] [-w] [-t [text for TAG] " 
-    echo " read/write data from/to NDEF tag "
-    echo "   -r, read tag "
-    echo "     short, read short information from tag  "
-    echo "     full,  read full information from tag "
-    echo "   -w, write information on tag  "
-    echo "   -t, text  for tag"
+    echo "Usage: termux-nfc subcommands... args..." 
+    echo ""
+    echo "Wrappers for all Android NFC APIs, except for get(), which is merged with connect() (see Example below)."
+    echo ""
+    echo "Byte array is supplied and returned in hexadecimal format, for example: 01234567DEADBEEF".
+    echo ""
+    echo "Return values or exceptions are in JSON format."
+    echo ""
+    echo "During the NFC connection, the auxiliary NFC activity should be kept in the foreground, possibly as picture-in-picture."
+    echo ""
+    echo "Subcommands:"
+    echo "    quit"
+    echo "    ---"
+    echo "    TagTechnology close"
+    echo "    TagTechnology isConnected"
+    echo "    TagTechnology getTag"
+    echo "    ---"
+    echo "    NfcA connect"
+    echo "    NfcA getAtqa"
+    echo "    NfcA getMaxTransceiveLength"
+    echo "    NfcA getSak"
+    echo "    NfcA getTimeout"
+    echo "    NfcA setTimeout <timeout>"
+    echo "    NfcA transceive <hex-data>"
+    echo "    ---"
+    echo "    NfcB connect"
+    echo "    NfcB getApplicationData"
+    echo "    NfcB getMaxTransceiveLength"
+    echo "    NfcB getProtocolInfo"
+    echo "    NfcB transceive <hex-data>"
+    echo "    ---"
+    echo "    NfcF connect"
+    echo "    NfcF getSystemCode"
+    echo "    NfcF getManufacturer"
+    echo "    NfcF getMaxTransceiveLength"
+    echo "    NfcF getSystemCode"
+    echo "    NfcF getTimeout"
+    echo "    NfcF setTimeout <timeout>"
+    echo "    NfcF transceive <hex-data>"
+    echo "    ---"
+    echo "    NfcV connect"
+    echo "    NfcV getDsfId"
+    echo "    NfcV getMaxTransceiveLength"
+    echo "    NfcV getResponseFlags"
+    echo "    NfcV transceive <hex-data>"
+    echo "    ---"
+    echo "    IsoDep connect"
+    echo "    IsoDep getHiLayerResponse"
+    echo "    IsoDep getHistoricalBytes"
+    echo "    IsoDep getMaxTransceiveLength"
+    echo "    IsoDep getTimeout"
+    echo "    IsoDep isExtendedLengthApduSupported"
+    echo "    IsoDep setTimeout <timeout>"
+    echo "    IsoDep transceive <hex-data>"
+    echo "    ---"
+    echo "    Ndef canMakeReadOnly"
+    echo "    Ndef connect"
+    echo "    Ndef getCachedNdefMessage"
+    echo "    Ndef getMaxSize"
+    echo "    Ndef getNdefMessage"
+    echo "    Ndef getType"
+    echo "    Ndef isWritable"
+    echo "    Ndef makeReadOnly"
+    echo "    Ndef writeNdefMessage <hex-message>"
+    echo "    ---"
+    echo "    MifareClassic authenticateSectorWithKeyA <sector_index> <key_hex>"
+    echo "    MifareClassic authenticateSectorWithKeyB <sector_index> <key_hex>"
+    echo "    MifareClassic blockToSector <block-index>"
+    echo "    MifareClassic connect"
+    echo "    MifareClassic decrement <block-index> <value>"
+    echo "    MifareClassic getBlockCount"
+    echo "    MifareClassic getBlockCountInSector <sector_index>"
+    echo "    MifareClassic getMaxTransceiveLength"
+    echo "    MifareClassic getSectorCount"
+    echo "    MifareClassic getSize"
+    echo "    MifareClassic getTimeout"
+    echo "    MifareClassic getType"
+    echo "    MifareClassic increment <block-index> <value>"
+    echo "    MifareClassic readBlock <block-index>"
+    echo "    MifareClassic restore <block-index>"
+    echo "    MifareClassic sectorToBlock <sector_index>" # Duplicate if blockToSector is preferred, pick one
+    echo "    MifareClassic setTimeout <timeout>"
+    echo "    MifareClassic transceive <hex-data>"
+    echo "    MifareClassic transfer <block-index>"
+    echo "    MifareClassic writeBlock <block-index> <hex-data>"
+    echo "    ---"
+    echo "    MifareUltralight connect"
+    echo "    MifareUltralight getMaxTransceiveLength"
+    echo "    MifareUltralight getTimeout"
+    echo "    MifareUltralight getType"
+    echo "    MifareUltralight readPages <page-offset>"
+    echo "    MifareUltralight setTimeout <timeout>"
+    echo "    MifareUltralight transceive <hex-data>"
+    echo "    MifareUltralight writePage <page-offset> <hex-data>"
+    echo "    ---"
+    echo "    NfcBarcode connect"
+    echo "    NfcBarcode getBarcode" # Assuming this is a method for NfcBarcode
+    echo "    NfcBarcode getType"
+    echo "    ---"
+    echo "    NdefFormatable connect"
+    echo "    NdefFormatable format <hex-message>"
+    echo "    NdefFormatable formatReadOnly <hex-message>"
+    echo ""
+    echo "Example:"
+    echo "    termux-nfc IsoDep connect  # Discover the current tag that you believe to support IsoDep and connect to it"
+    echo "    termux-nfc IsoDep transceive 01020304  # Transceive data with the connected IsoDep tag"
+    echo "    termux-nfc IsoDep transceive deadbeef  # Keep the state and transceive more data"
+    echo "    termux-nfc TagTechnology close  # Close the current tag connection and clean the state"
+    echo "    termux-nfc quit  # Exit the auxiliary NFC activity"
+
+
     exit 0
 }
 
-ARG_R=""
-OPT_R=""
-ARG_W=""
-OPT_T=""
-ARG_T=""
+if [ $# -eq 0 ] || 
+   { [ $# -eq 1 ] && { [ "$1" = "-h" ] || [ "$1" = "--help" ] || [ "$1" = "help" ]; }; }
+then
+    show_usage
+    exit 1
+fi
 
-PARAM=""
-
-if [ $# -eq 0 ];then show_usage;fi
-
-while getopts ":r:t:w" opt
-do
-  case "$opt" in
-      r) ARG_R="--es mode read"; OPT_R="--es param $OPTARG"; ;;
-      w) ARG_W="--es mode write";;
-      t) ARG_T="--es param text --es value"; OPT_T="$OPTARG"; ;;
-      ?) echo "Error: unknown parameters: $opt $OPTARG;";show_usage; ;;
-  esac 
+api_args=()
+for ((i=1; i<=$#; ++i)); do
+  args+=("--es" "arg$i" "${!i}")
 done
 
-
-shift $((OPTIND-1))
-
-if [ "$#" != 0 ]; then echo "Error: too many parameters!"; show_usage;fi
-if [ -n "$ARG_R" ]; then if [ -n "$ARG_W" ]; then echo "Error: Incompatible parameters! \"-r and \"-n";show_usage;fi;fi
-
-
-
-if [ -n "$ARG_R" ]; then set -- "$@" $ARG_R $OPT_R;fi
-if [ -n "$ARG_W" ]; then set -- "$@" $ARG_W;fi
-if [ -n "$ARG_T" ]; then set -- "$@" $ARG_T "$OPT_T";fi
-@TERMUX_PREFIX@/libexec/termux-api Nfc "$@"
+@TERMUX_PREFIX@/libexec/termux-api Nfc "${args[@]}"

--- a/scripts/termux-nfc.in
+++ b/scripts/termux-nfc.in
@@ -3,19 +3,15 @@
 set -e -u
 
 show_usage() {
-    echo "Usage: termux-nfc subcommands... args..." 
+    echo "Usage: termux-nfc -" 
     echo ""
-    echo "Wrappers for all Android NFC APIs, except for get(), which is merged with connect() (see Example below)."
+    echo "Reads from stdin line by line, parse each line as JSON object specifying an NFC API, and execute it."
+    echo ""
+    echo 'Format: {"class": "<CLASSNAME>", "method": "<METHODNAME>", "args": [ARG1, ARG2, ...]}'
     echo ""
     echo "Byte array is supplied and returned in hexadecimal format, for example: 01234567DEADBEEF".
     echo ""
-    echo "Return values or exceptions are in JSON format."
-    echo ""
-    echo "During the NFC connection, the auxiliary NFC activity should be kept in the foreground, possibly as picture-in-picture."
-    echo ""
-    echo "Subcommands:"
-    echo "    quit"
-    echo "    ---"
+    echo "Class/Method/Args:"
     echo "    TagTechnology close"
     echo "    TagTechnology isConnected"
     echo "    TagTechnology getTag"
@@ -107,12 +103,10 @@ show_usage() {
     echo "    NdefFormatable formatReadOnly <hex-message>"
     echo ""
     echo "Example:"
-    echo "    termux-nfc IsoDep connect  # Discover the current tag that you believe to support IsoDep and connect to it"
-    echo "    termux-nfc IsoDep transceive 01020304  # Transceive data with the connected IsoDep tag"
-    echo "    termux-nfc IsoDep transceive deadbeef  # Keep the state and transceive more data"
-    echo "    termux-nfc TagTechnology close  # Close the current tag connection and clean the state"
-    echo "    termux-nfc quit  # Exit the auxiliary NFC activity"
-
+    echo '    {"class":"IsoDep", "method": "connect", "args": []}'
+    echo '    {"class":"IsoDep", "method": "transceive", "args": ["01020304"]}'
+    echo '    {"class":"IsoDep", "method": "transceive", "args": ["deadbeef"]}'
+    echo '    {"class":"TagTechnology", "method": "close", "args": []}'
 
     exit 0
 }
@@ -124,9 +118,4 @@ then
     exit 1
 fi
 
-api_args=()
-for ((i=1; i<=$#; ++i)); do
-  args+=("--es" "arg$i" "${!i}")
-done
-
-@TERMUX_PREFIX@/libexec/termux-api Nfc "${args[@]}"
+@TERMUX_PREFIX@/libexec/termux-api Nfc

--- a/scripts/termux-nfc.in
+++ b/scripts/termux-nfc.in
@@ -7,7 +7,8 @@ show_usage() {
     echo ""
     echo "Reads from stdin line by line, parse each line as JSON object specifying an NFC API, and execute it."
     echo ""
-    echo 'Format: {"class": "<CLASSNAME>", "method": "<METHODNAME>", "args": [ARG1, ARG2, ...]}'
+    echo "Tag discovery: {"op": "discoverTag"}"
+    echo 'API Format: {"op": "api", "class": "<CLASSNAME>", "method": "<METHODNAME>", "args": [ARG1, ARG2, ...]}'
     echo ""
     echo "Byte array is supplied and returned in hexadecimal format, for example: 01234567DEADBEEF".
     echo ""
@@ -103,10 +104,15 @@ show_usage() {
     echo "    NdefFormatable formatReadOnly <hex-message>"
     echo ""
     echo "Example:"
-    echo '    {"class":"IsoDep", "method": "connect", "args": []}'
-    echo '    {"class":"IsoDep", "method": "transceive", "args": ["01020304"]}'
-    echo '    {"class":"IsoDep", "method": "transceive", "args": ["deadbeef"]}'
-    echo '    {"class":"TagTechnology", "method": "close", "args": []}'
+    echo '    {"op": "discoverTag"}'
+    echo '    {"op": "api", "class":"IsoDep", "method": "connect", "args": []}'
+    echo '    {"op": "api", "class":"IsoDep", "method": "transceive", "args": ["01020304"]}'
+    echo '    {"op": "api", "class":"IsoDep", "method": "transceive", "args": ["deadbeef"]}'
+    echo '    {"op": "api", "class":"TagTechnology", "method": "close", "args": []}'
+    echo '    {"op": "api", "class":"MifareClassic", "method": "connect", "args": []}'
+    echo '    {"op": "api", "class":"MifareClassic", "method": "authenticateSectorWithKeyA", "args": [0, "FFFFFFFFFFFFFFFF"]}'
+    echo '    {"op": "api", "class":"MifareClassic", "method": "readBlock", "args": [0]}'
+    echo '    {"op": "api", "class":"TagTechnology", "method": "close", "args": []}'
 
     exit 0
 }

--- a/scripts/termux-nfc.in
+++ b/scripts/termux-nfc.in
@@ -80,7 +80,7 @@ show_usage() {
     echo "    MifareClassic increment <block-index> <value>"
     echo "    MifareClassic readBlock <block-index>"
     echo "    MifareClassic restore <block-index>"
-    echo "    MifareClassic sectorToBlock <sector_index>" # Duplicate if blockToSector is preferred, pick one
+    echo "    MifareClassic sectorToBlock <sector_index>"
     echo "    MifareClassic setTimeout <timeout>"
     echo "    MifareClassic transceive <hex-data>"
     echo "    MifareClassic transfer <block-index>"
@@ -96,7 +96,7 @@ show_usage() {
     echo "    MifareUltralight writePage <page-offset> <hex-data>"
     echo "    ---"
     echo "    NfcBarcode connect"
-    echo "    NfcBarcode getBarcode" # Assuming this is a method for NfcBarcode
+    echo "    NfcBarcode getBarcode"
     echo "    NfcBarcode getType"
     echo "    ---"
     echo "    NdefFormatable connect"

--- a/scripts/termux-nfc.in
+++ b/scripts/termux-nfc.in
@@ -106,8 +106,7 @@ show_usage() {
     echo "Example:"
     echo '    {"op": "discoverTag"}'
     echo '    {"op": "api", "class":"IsoDep", "method": "connect", "args": []}'
-    echo '    {"op": "api", "class":"IsoDep", "method": "transceive", "args": ["01020304"]}'
-    echo '    {"op": "api", "class":"IsoDep", "method": "transceive", "args": ["deadbeef"]}'
+    echo '    {"op": "api", "class":"IsoDep", "method": "transceive", "args": ["00A40000023F00"]}'
     echo '    {"op": "api", "class":"TagTechnology", "method": "close", "args": []}'
     echo '    {"op": "api", "class":"MifareClassic", "method": "connect", "args": []}'
     echo '    {"op": "api", "class":"MifareClassic", "method": "authenticateSectorWithKeyA", "args": [0, "FFFFFFFFFFFFFFFF"]}'

--- a/scripts/termux-nfc.in
+++ b/scripts/termux-nfc.in
@@ -106,10 +106,10 @@ show_usage() {
     echo "Example:"
     echo '    {"op": "discoverTag"}'
     echo '    {"op": "api", "class":"IsoDep", "method": "connect", "args": []}'
-    echo '    {"op": "api", "class":"IsoDep", "method": "transceive", "args": ["00A40000023F00"]}'
+    echo '    {"op": "api", "class":"IsoDep", "method": "transceive", "args": [{"format": "hex", "value": "00A40000023F00"}]}'
     echo '    {"op": "api", "class":"TagTechnology", "method": "close", "args": []}'
     echo '    {"op": "api", "class":"MifareClassic", "method": "connect", "args": []}'
-    echo '    {"op": "api", "class":"MifareClassic", "method": "authenticateSectorWithKeyA", "args": [0, "FFFFFFFFFFFFFFFF"]}'
+    echo '    {"op": "api", "class":"MifareClassic", "method": "authenticateSectorWithKeyA", "args": [0, {"format": "hex", "value": "FFFFFFFFFFFFFFFF"}]}'
     echo '    {"op": "api", "class":"MifareClassic", "method": "readBlock", "args": [0]}'
     echo '    {"op": "api", "class":"TagTechnology", "method": "close", "args": []}'
 

--- a/scripts/termux-nfc.in
+++ b/scripts/termux-nfc.in
@@ -5,10 +5,10 @@ set -e -u
 show_usage() {
     echo "Usage: termux-nfc -" 
     echo ""
-    echo "Reads from stdin line by line, parse each line as JSON object specifying an NFC API, and execute it."
+    echo "Reads from stdin line by line, parse each line as JSON object specifying an NFC operation, and execute it."
     echo ""
     echo "Tag discovery: {"op": "discoverTag"}"
-    echo 'API Format: {"op": "api", "class": "<CLASSNAME>", "method": "<METHODNAME>", "args": [ARG1, ARG2, ...]}'
+    echo 'API: {"op": "api", "class": "<CLASSNAME>", "method": "<METHODNAME>", "args": [ARG1, ARG2, ...]}'
     echo ""
     echo "Byte array is supplied and returned in hexadecimal format, for example: 01234567DEADBEEF".
     echo ""

--- a/scripts/termux-nfc.in
+++ b/scripts/termux-nfc.in
@@ -116,8 +116,7 @@ show_usage() {
     exit 0
 }
 
-if [ $# -eq 0 ] || 
-   { [ $# -eq 1 ] && { [ "$1" != "-" ]; }; }
+if [ $# -ne 1 ] || [ "$1" != "-" ];
 then
     show_usage
     exit 1

--- a/scripts/termux-nfc.in
+++ b/scripts/termux-nfc.in
@@ -65,13 +65,13 @@ show_usage() {
     echo "    Ndef makeReadOnly"
     echo "    Ndef writeNdefMessage <hex-message>"
     echo "    ---"
-    echo "    MifareClassic authenticateSectorWithKeyA <sector_index> <key_hex>"
-    echo "    MifareClassic authenticateSectorWithKeyB <sector_index> <key_hex>"
+    echo "    MifareClassic authenticateSectorWithKeyA <sector-index> <hex-key>"
+    echo "    MifareClassic authenticateSectorWithKeyB <sector-index> <hex-key>"
     echo "    MifareClassic blockToSector <block-index>"
     echo "    MifareClassic connect"
     echo "    MifareClassic decrement <block-index> <value>"
     echo "    MifareClassic getBlockCount"
-    echo "    MifareClassic getBlockCountInSector <sector_index>"
+    echo "    MifareClassic getBlockCountInSector <sector-index>"
     echo "    MifareClassic getMaxTransceiveLength"
     echo "    MifareClassic getSectorCount"
     echo "    MifareClassic getSize"
@@ -80,7 +80,7 @@ show_usage() {
     echo "    MifareClassic increment <block-index> <value>"
     echo "    MifareClassic readBlock <block-index>"
     echo "    MifareClassic restore <block-index>"
-    echo "    MifareClassic sectorToBlock <sector_index>"
+    echo "    MifareClassic sectorToBlock <sector-index>"
     echo "    MifareClassic setTimeout <timeout>"
     echo "    MifareClassic transceive <hex-data>"
     echo "    MifareClassic transfer <block-index>"
@@ -117,7 +117,7 @@ show_usage() {
 }
 
 if [ $# -eq 0 ] || 
-   { [ $# -eq 1 ] && { [ "$1" = "-h" ] || [ "$1" = "--help" ] || [ "$1" = "help" ]; }; }
+   { [ $# -eq 1 ] && { [ "$1" != "-" ]; }; }
 then
     show_usage
     exit 1


### PR DESCRIPTION
Add all APIs (78 in total) listed in the [official doc](https://developer.android.com/reference/android/nfc/tech/TagTechnology) for all NFC technologies (NfcA, NfcB, NfcF, NfcV, IsoDep, Ndef, MifareClassic, MifareUltralight, NfcBarcode, NdefFormatable).

See also https://github.com/termux/termux-api/pull/796.

The API call request in JSON format is passed into stdin of termux-api in the format of:
- either `{"op": "discoverTag"}`
- or `{"op": "api", "class": "<CLASSNAME>", "method": "<METHODNAME>", "args": [<ARG1>, <ARG2>, ...]}`

This is a thin wrapper around the native APIs without UI ergonomic considerations. It's supposed to be used e.g. in bash as a coprocess. To directly use it as a REPL, use `rlwrap termux-nfc -`.

# Examples

## Normal usage

```sh
$ termux-nfc -
{"op": "discoverTag"}
{"status":"success","result":{"id":{"format":"hex","value":"DEADBEEF"},"techList": "android.nfc.tech.IsoDep","android.nfc.tech.NfcA","android.nfc.tech.MifareClassic"]}}
{"op": "api", "class":"IsoDep", "method": "connect", "args": []}
{"status": "success"}
{"op": "api", "class":"IsoDep", "method": "transceive", "args": [{"format": "hex", "value": "00A40000023F00"}]}
{"status": "success", "result": {"format": "hex", "value": "01020304DEADBEEF"}}}
{"op": "api", "class":"TagTechnology", "method": "close", "args": []}
{"status": "success"}
{"op": "api", "class":"MifareClassic", "method": "connect", "args": []}
{"status": "success"}
{"op": "api", "class":"MifareClassic", "method": "authenticateSectorWithKeyA", "args": [0, {"format":"hex","value":"FFFFFFFFFFFFFFFF"}]}
{"status": "success", "result": true}
{"op": "api", "class":"MifareClassic", "method": "readBlock", "args": [0]}
{"status": "success", "result": {"format": "hex", "value": {"format": "hex", "value": "01020304DEADBEEF"}}}
{"op": "api", "class":"TagTechnology", "method": "close", "args": []}
{"status": "success"}
```

Lines with `"op"` are your console inputs, while lines with `"status"` are output from termux-api.

## As REPL

```sh
$ rlwrap termux-nfc -
... (same as normal usage)
```

With rlwrap, you can use advanced command-line editing keybinds like up/down.

## One-liner

With the help of bash herestring, commands can be typed before they are invoked:

```sh
$ termux-nfc - <<<'{"op": "discoverTag"}'$'\n''{"op": "api", "class":"IsoDep", "method": "connect", "args": []}'$'\n''{"op": "api", "class":"IsoDep", "method": "transceive", "args": [{"format": "hex", "value": "00A40000023F00"}]}'$'\n'
{"status":"success","result":{"id":{"format":"hex","value":"DEADBEEF"},"techList": "android.nfc.tech.IsoDep","android.nfc.tech.NfcA","android.nfc.tech.MifareClassic"]}}
{"status": "success"}
{"status": "success", "result": {"format": "hex", "value": "01020304DEADBEEF"}}}
```

## As bash coprocess

```bash
coproc NFC_REPL { termux-nfc - ; }

function run-nfc {
	local msg="$1"
	echo "$msg" >&"${NFC_REPL[1]}"
	local response
	read -r response <&"${NFC_REPL[0]}"
	echo "$response"
}

run-nfc '{"op": "discoverTag"}'
run-nfc '{"op": "api", "class":"IsoDep", "method": "connect", "args": []}'
run-nfc '{"op": "api", "class":"IsoDep", "method": "transceive", "args": [{"format": "hex", "value": "00A40000023F00"}]}'
run-nfc '{"op": "api", "class":"TagTechnology", "method": "close", "args": []}'
```