### PR TITLE
termux-brightness: return current brightness when called without arguments

### DIFF
--- a/scripts/termux-brightness.in
+++ b/scripts/termux-brightness.in
@@ -5,19 +5,25 @@ SCRIPTNAME=termux-brightness
 show_usage() {
     echo "Usage: $SCRIPTNAME brightness"
     echo "Set the screen brightness between 0 and 255 or auto"
+    echo "If no argument is given, return the current brightness"
     exit 0
 }
 
-if [ $# != 1 ]; then
+if [ $# -gt 1 ]; then
     show_usage
 fi
 
-if ! [[ $1 =~ ^([0-9]+)|auto$ ]]; then
+if [ $# -eq 0 ]; then
+    @TERMUX_PREFIX@/libexec/termux-api Brightness
+    exit 0
+fi
+
+if ! [[ $1 =~ ^([0-9]+|auto)$ ]]; then
     echo "ERROR: Arg must be a number between 0 - 255 or auto!"
     show_usage
 fi
 
-if [ "$1" == auto ]; then
+if [ "$1" = auto ]; then
 ARGS="--ez auto true"
 else
 ARGS="--ei brightness $1 --ez auto false"


### PR DESCRIPTION
Allow `termux-brightness` to return the current screen brightness when
called without arguments.

Previously, it showed a usage message. It now returns the current
brightness value instead.

Setting brightness behavior is unchanged.

Depends on:
https://github.com/termux/termux-api/pull/851